### PR TITLE
feat(cli): render tool calls as bordered box widgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "tui-widget-list",
 ]
 
 [[package]]
@@ -2196,7 +2197,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2240,7 +2241,7 @@ dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-widgets",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2259,7 +2260,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2889,7 +2890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "unicode-linebreak",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3216,6 +3217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-widget-list"
+version = "0.15.0"
+source = "git+https://github.com/concats-org/tui-widget-list.git?branch=scrolling#8d3422571e5daabd90235c6a4f6a2ab49b1c3fbf"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,7 +3278,7 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3279,9 +3289,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ tracing = "0.1.41"
 tracing-indicatif = "0.3.6"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
+[patch.crates-io]
+tui-widget-list = { git = "https://github.com/concats-org/tui-widget-list.git", branch = "scrolling" }
+
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tui-widget-list = "0.15"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use agent_client_protocol::{
     ContentBlock, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectOptions, SessionNotification, SessionUpdate,
+    SessionConfigSelectOptions, SessionNotification, SessionUpdate, ToolCall,
 };
 use concats_core::session::{SessionConfig, SessionEvent, SessionHandle, start_session};
 use ratatui_textarea::TextArea;
@@ -22,6 +22,7 @@ pub enum Message {
     User(String),
     Agent(String),
     System(String),
+    ToolCall(ToolCall),
 }
 
 /// Which panel currently has focus.
@@ -69,7 +70,7 @@ pub struct SessionTab<'a> {
     pub textarea: TextArea<'a>,
     pub status: String,
     pub waiting: bool,
-    pub scroll_offset: u16,
+    pub list: tui_widget_list::ListState,
     pub stderr_lines: Vec<String>,
     pub stderr_scroll: u16,
     pub show_stderr: bool,
@@ -104,7 +105,7 @@ impl<'a> SessionTab<'a> {
             textarea,
             status: "connected".into(),
             waiting: false,
-            scroll_offset: 0,
+            list: tui_widget_list::ListState::default(),
             stderr_lines: Vec::new(),
             stderr_scroll: 0,
             show_stderr: false,
@@ -249,8 +250,7 @@ impl<'a> SessionTab<'a> {
                 }
             }
             SessionUpdate::ToolCall(tc) => {
-                self.messages
-                    .push(Message::System(format!("Tool: {}", tc.title)));
+                self.messages.push(Message::ToolCall(tc));
             }
             SessionUpdate::CurrentModeUpdate(mode_update) => {
                 self.current_mode = Some(mode_update.current_mode_id.to_string());
@@ -471,7 +471,11 @@ impl<'a> App<'a> {
         tokio::spawn(async move {
             let mut rx = session_rx;
             while let Some(event) = rx.recv().await {
-                if fan_in_tx.send((id, FanInEvent::Session(event))).await.is_err() {
+                if fan_in_tx
+                    .send((id, FanInEvent::Session(event)))
+                    .await
+                    .is_err()
+                {
                     break;
                 }
             }

--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -193,7 +193,7 @@ async fn handle_sessions_keys(app: &mut App<'_>, key: KeyEvent) -> miette::Resul
 fn scroll_focused_panel(tab: &mut crate::app::SessionTab, delta: i16) {
     match tab.focused_panel {
         FocusedPanel::Conversation => {
-            tab.scroll_offset = apply_scroll_delta(tab.scroll_offset, delta);
+            tab.list.scroll_by(delta);
         }
         FocusedPanel::Stderr => {
             tab.stderr_scroll = apply_scroll_delta(tab.stderr_scroll, delta);
@@ -300,7 +300,7 @@ fn scroll_under_mouse(
 
         if rect_contains(panel_chunks[0], column, row) {
             tab.focused_panel = FocusedPanel::Conversation;
-            tab.scroll_offset = apply_scroll_delta(tab.scroll_offset, delta);
+            tab.list.scroll_by(delta);
             return true;
         }
 
@@ -311,7 +311,7 @@ fn scroll_under_mouse(
         }
     } else {
         tab.focused_panel = FocusedPanel::Conversation;
-        tab.scroll_offset = apply_scroll_delta(tab.scroll_offset, delta);
+        tab.list.scroll_by(delta);
         return true;
     }
 

--- a/crates/cli/src/ui.rs
+++ b/crates/cli/src/ui.rs
@@ -1,14 +1,18 @@
 use ratatui::{
     Frame,
+    buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect, Spacing},
     style::{Color, Modifier, Style},
     symbols::{merge::MergeStrategy, scrollbar::Set},
     text::{Line, Span, Text},
     widgets::{
         Block, BorderType, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation,
-        ScrollbarState, Wrap,
+        ScrollbarState, Widget, Wrap,
     },
 };
+use tui_widget_list::{ListBuilder, ListView};
+
+use agent_client_protocol::ToolKind;
 
 use crate::{
     app::{App, FocusedPanel, Message, SessionTab},
@@ -294,6 +298,205 @@ fn render_agent_picker(frame: &mut Frame, picker: &crate::app::AgentPickerState)
     frame.render_widget(list, popup_area);
 }
 
+/// A widget representing a single conversation message.
+struct MessageWidget<'a> {
+    paragraph: Paragraph<'a>,
+    height: u16,
+}
+
+impl MessageWidget<'_> {
+    fn from_message(msg: &Message, width: u16) -> MessageWidget<'_> {
+        let w = width.max(1) as usize;
+        match msg {
+            Message::User(text) => {
+                let line = Line::from(vec![
+                    Span::styled(
+                        "> ",
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(text.as_str()),
+                ]);
+                let height = (text.chars().count() + 2).div_ceil(w).max(1) as u16;
+                MessageWidget {
+                    paragraph: Paragraph::new(line).wrap(Wrap { trim: false }),
+                    height,
+                }
+            }
+            Message::Agent(text) => {
+                let lines: Vec<Line> = text
+                    .lines()
+                    .map(|line| {
+                        Line::from(Span::styled(line, Style::default().fg(Color::Cyan)))
+                    })
+                    .collect();
+                let height: u16 = text
+                    .lines()
+                    .map(|l| l.chars().count().div_ceil(w).max(1) as u16)
+                    .sum::<u16>()
+                    .max(1);
+                MessageWidget {
+                    paragraph: Paragraph::new(lines).wrap(Wrap { trim: false }),
+                    height,
+                }
+            }
+            Message::System(text) => {
+                let line = Line::from(vec![
+                    Span::styled("[", Style::default().fg(Color::Yellow)),
+                    Span::styled(text.as_str(), Style::default().fg(Color::Yellow)),
+                    Span::styled("]", Style::default().fg(Color::Yellow)),
+                ]);
+                let height = (text.chars().count() + 2).div_ceil(w).max(1) as u16;
+                MessageWidget {
+                    paragraph: Paragraph::new(line).wrap(Wrap { trim: false }),
+                    height,
+                }
+            }
+            Message::ToolCall(tc) => {
+                // Fallback: should be rendered via ToolCallWidget, but handle gracefully.
+                let text = &tc.title;
+                let line = Line::from(Span::styled(
+                    format!("[Tool: {text}]"),
+                    Style::default().fg(Color::Yellow),
+                ));
+                let height = (text.chars().count() + 8).div_ceil(w).max(1) as u16;
+                MessageWidget {
+                    paragraph: Paragraph::new(line).wrap(Wrap { trim: false }),
+                    height,
+                }
+            }
+        }
+    }
+}
+
+impl Widget for MessageWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        self.paragraph.render(area, buf);
+    }
+}
+
+/// A widget rendering a tool call as a bordered box.
+struct ToolCallWidget<'a> {
+    block: Block<'a>,
+    lines: Vec<Line<'a>>,
+    height: u16,
+}
+
+impl ToolCallWidget<'_> {
+    fn from_tool_call(tc: &agent_client_protocol::ToolCall, _width: u16) -> ToolCallWidget<'_> {
+        let kind_label = match tc.kind {
+            ToolKind::Read => "Read",
+            ToolKind::Edit => "Edit",
+            ToolKind::Delete => "Delete",
+            ToolKind::Move => "Move",
+            ToolKind::Search => "Search",
+            ToolKind::Execute => "Execute",
+            ToolKind::Think => "Think",
+            ToolKind::Fetch => "Fetch",
+            ToolKind::SwitchMode => "SwitchMode",
+            _ => "Tool",
+        };
+
+        let border_color = Color::DarkGray;
+
+        let mut lines = Vec::new();
+        if !tc.title.is_empty() {
+            lines.push(Line::from(Span::styled(
+                tc.title.clone(),
+                Style::default().fg(Color::White),
+            )));
+        }
+
+        for loc in &tc.locations {
+            let path_str = loc.path.display().to_string();
+            let loc_text = if let Some(line) = loc.line {
+                format!("path: {path_str}:{line}")
+            } else {
+                format!("path: {path_str}")
+            };
+            lines.push(Line::from(Span::styled(
+                loc_text,
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+
+        let height = lines.len() as u16 + 2; // +2 for borders
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(Span::styled(
+                format!(" {kind_label} "),
+                Style::default()
+                    .fg(border_color)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .border_style(Style::default().fg(border_color));
+
+        ToolCallWidget {
+            block,
+            lines,
+            height,
+        }
+    }
+}
+
+impl Widget for ToolCallWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let paragraph = Paragraph::new(self.lines).block(self.block);
+        paragraph.render(area, buf);
+    }
+}
+
+/// Wrapper enum so `ListBuilder` can return either message or tool-call widgets.
+enum ConversationWidget<'a> {
+    Message(MessageWidget<'a>),
+    ToolCall(ToolCallWidget<'a>),
+}
+
+impl ConversationWidget<'_> {
+    fn height(&self) -> u16 {
+        match self {
+            ConversationWidget::Message(w) => w.height,
+            ConversationWidget::ToolCall(w) => w.height,
+        }
+    }
+}
+
+impl Widget for ConversationWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        match self {
+            ConversationWidget::Message(w) => w.render(area, buf),
+            ConversationWidget::ToolCall(w) => w.render(area, buf),
+        }
+    }
+}
+
+/// Render the conversation as a `ListView` of per-message widgets.
+fn render_conversation_list(frame: &mut Frame, tab: &mut SessionTab, area: Rect) {
+    let messages = &tab.messages;
+    let msg_count = messages.len();
+
+    let builder = ListBuilder::new(move |context| {
+        let msg = &messages[context.index];
+        let widget = match msg {
+            Message::ToolCall(tc) => {
+                let w = ToolCallWidget::from_tool_call(tc, context.cross_axis_size);
+                ConversationWidget::ToolCall(w)
+            }
+            other => ConversationWidget::Message(MessageWidget::from_message(
+                other,
+                context.cross_axis_size,
+            )),
+        };
+        let height = widget.height();
+        (widget, height)
+    });
+
+    let list_view = ListView::new(builder, msg_count);
+    frame.render_stateful_widget(list_view, area, &mut tab.list);
+}
+
 pub fn render_session_tab(frame: &mut Frame, tab: &mut SessionTab, tick: usize, area: Rect) {
     let _ = tick; // tick is used in the tab bar, not directly here
     let chunks = Layout::default()
@@ -303,39 +506,6 @@ pub fn render_session_tab(frame: &mut Frame, tab: &mut SessionTab, tick: usize, 
             Constraint::Length(session_input_height(tab, area.width)), // input (+ optional fork context block)
         ])
         .split(area);
-
-    // Build conversation lines.
-    let mut conv_lines: Vec<Line> = Vec::new();
-    for msg in &tab.messages {
-        match msg {
-            Message::User(text) => {
-                conv_lines.push(Line::from(vec![
-                    Span::styled(
-                        "> ",
-                        Style::default()
-                            .fg(Color::Green)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::raw(text),
-                ]));
-            }
-            Message::Agent(text) => {
-                for line in text.lines() {
-                    conv_lines.push(Line::from(Span::styled(
-                        line,
-                        Style::default().fg(Color::Cyan),
-                    )));
-                }
-            }
-            Message::System(text) => {
-                conv_lines.push(Line::from(vec![
-                    Span::styled("[", Style::default().fg(Color::Yellow)),
-                    Span::styled(text, Style::default().fg(Color::Yellow)),
-                    Span::styled("]", Style::default().fg(Color::Yellow)),
-                ]));
-            }
-        }
-    }
 
     if tab.show_stderr {
         // Split the main area horizontally: conversation left, stderr right.
@@ -347,22 +517,7 @@ pub fn render_session_tab(frame: &mut Frame, tab: &mut SessionTab, tick: usize, 
             ])
             .split(chunks[0]);
 
-        let conv_len = conv_lines.len();
-        let conversation = Paragraph::new(conv_lines)
-            .wrap(Wrap { trim: false })
-            .scroll((tab.scroll_offset, 0));
-        frame.render_widget(conversation, horiz[0]);
-
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight).symbols(Set {
-            track: "\u{2502}",
-            thumb: "\u{2588}",
-            begin: "\u{25b2}",
-            end: "\u{25bc}",
-        });
-        let mut scrollbar_state = ScrollbarState::default()
-            .content_length(conv_len)
-            .position(tab.scroll_offset as usize);
-        frame.render_stateful_widget(scrollbar, horiz[0], &mut scrollbar_state);
+        render_conversation_list(frame, tab, horiz[0]);
 
         // Stderr panel.
         let stderr_lines: Vec<Line> = tab
@@ -407,22 +562,7 @@ pub fn render_session_tab(frame: &mut Frame, tab: &mut SessionTab, tick: usize, 
         );
     } else {
         // Full-width conversation.
-        let conv_len = conv_lines.len();
-        let conversation = Paragraph::new(conv_lines)
-            .wrap(Wrap { trim: false })
-            .scroll((tab.scroll_offset, 0));
-        frame.render_widget(conversation, chunks[0]);
-
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight).symbols(Set {
-            track: "\u{2502}",
-            thumb: "\u{2588}",
-            begin: "\u{25b2}",
-            end: "\u{25bc}",
-        });
-        let mut scrollbar_state = ScrollbarState::default()
-            .content_length(conv_len)
-            .position(tab.scroll_offset as usize);
-        frame.render_stateful_widget(scrollbar, chunks[0], &mut scrollbar_state);
+        render_conversation_list(frame, tab, chunks[0]);
     }
 
     // Input area using TextArea widget.


### PR DESCRIPTION
Refactor the "conversation" view to render a list of widgets instead of one paragraf. With that refactor replace plain "[Tool: title]" system messages with rich ToolCallWidget boxes that display the tool kind, file paths and other meta data.