### PR TITLE
fix hooks

### DIFF
--- a/crates/hooks/src/amp.rs
+++ b/crates/hooks/src/amp.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use concats_core::error::{Error, Result};
 
-use crate::{HandlerAction, InstallScope, find_worktree_root, plugin};
+use crate::{HandlerAction, InstallScope, plugin};
 
 const AGENT: &str = "amp";
 const PLUGIN_TEMPLATE: &str = include_str!("../plugins/amp.ts");

--- a/crates/hooks/src/amp.rs
+++ b/crates/hooks/src/amp.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use concats_core::error::{Error, Result};
 
-use crate::{ install, HandlerAction, InstallScope, find_worktree_root, plugin};
+use crate::{HandlerAction, InstallScope, find_worktree_root, plugin};
 
 const AGENT: &str = "amp";
 const PLUGIN_TEMPLATE: &str = include_str!("../plugins/amp.ts");

--- a/crates/hooks/src/copilot.rs
+++ b/crates/hooks/src/copilot.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use concats_core::error::{Error, Result};
 
-use crate::{HandlerAction, InstallScope, find_worktree_root, json_config};
+use crate::{HandlerAction, InstallScope, json_config};
 
 const AGENT: &str = "copilot";
 

--- a/crates/hooks/src/copilot.rs
+++ b/crates/hooks/src/copilot.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use concats_core::error::{Error, Result};
 
-use crate::{ install, HandlerAction, InstallScope, find_worktree_root, json_config};
+use crate::{HandlerAction, InstallScope, find_worktree_root, json_config};
 
 const AGENT: &str = "copilot";
 

--- a/crates/hooks/src/cursor.rs
+++ b/crates/hooks/src/cursor.rs
@@ -5,7 +5,7 @@ use std::{
 
 use concats_core::error::{Error, Result};
 
-use crate::{ find_worktree_root, HandlerAction, InstallScope, json_config, };
+use crate::{HandlerAction, InstallScope, json_config};
 
 const AGENT: &str = "cursor";
 

--- a/crates/hooks/src/droid.rs
+++ b/crates/hooks/src/droid.rs
@@ -5,7 +5,7 @@ use std::{
 
 use concats_core::error::{Error, Result};
 
-use crate::{HandlerAction, find_worktree_root, InstallScope, json_config};
+use crate::{HandlerAction, InstallScope, json_config};
 
 const AGENT: &str = "droid";
 const MATCHER: &str = "^(Edit|Write|Create|ApplyPatch)$";

--- a/crates/hooks/src/gemini.rs
+++ b/crates/hooks/src/gemini.rs
@@ -5,7 +5,7 @@ use std::{
 
 use concats_core::error::{Error, Result};
 
-use crate::{HandlerAction, find_worktree_root, InstallScope, json_config};
+use crate::{HandlerAction, InstallScope, json_config};
 
 const AGENT: &str = "gemini";
 const MATCHER: &str = "write_file|replace";

--- a/crates/hooks/src/opencode.rs
+++ b/crates/hooks/src/opencode.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use concats_core::error::{Error, Result};
 
-use crate::{ install, HandlerAction, InstallScope, find_worktree_root, plugin};
+use crate::{HandlerAction, InstallScope, find_worktree_root, plugin};
 
 const AGENT: &str = "opencode";
 const PLUGIN_TEMPLATE: &str = include_str!("../plugins/opencode.ts");

--- a/crates/hooks/src/opencode.rs
+++ b/crates/hooks/src/opencode.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use concats_core::error::{Error, Result};
 
-use crate::{HandlerAction, InstallScope, find_worktree_root, plugin};
+use crate::{HandlerAction, InstallScope, plugin};
 
 const AGENT: &str = "opencode";
 const PLUGIN_TEMPLATE: &str = include_str!("../plugins/opencode.ts");

--- a/crates/hooks/src/windsurf.rs
+++ b/crates/hooks/src/windsurf.rs
@@ -5,7 +5,7 @@ use std::{
 
 use concats_core::error::{Error, Result};
 
-use crate::{HandlerAction, find_worktree_root, InstallScope, json_config};
+use crate::{HandlerAction, InstallScope, json_config};
 
 const AGENT: &str = "windsurf";
 


### PR DESCRIPTION
The `install` module was removed in https://github.com/concats-org/concats/commit/98d6813b2e61807e84f0b36b35ca1ba6ec8fa083 and replaced by `plugin`, `json_config`, and `toml_config`. The agent bodies were updated to call the new helpers directly, but the old `install` survived the rebase, causing `cargo build` to fail with E0432. Drop the stale token so the imports match the sibling modules.