### PR TITLE
feat(cli): add `concats init` for project setup

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -14,6 +14,14 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Set up concats in the current repository: install hooks for every
+    /// detected agent at the project level.
+    Init {
+        /// Project root (defaults to the enclosing git worktree).
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+    },
+
     /// Show the turn history of a session.
     Log {
         /// Session ref (e.g. session-a, session-a~3, abc1234).
@@ -77,9 +85,12 @@ pub enum Commands {
 
 #[derive(Subcommand)]
 pub enum HooksAction {
-    /// Install concats hooks for detected agents.
+    /// Install concats hooks for one or more named agents.
+    ///
+    /// To install for every detected agent at once, use `concats init`.
     Install {
-        /// Agents to install for (default: auto-detect installed agents).
+        /// Agents to install for.
+        #[arg(required = true)]
         agents: Vec<String>,
 
         /// Project root for Claude project-level hooks (defaults to current directory).

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,4 +1,8 @@
-use std::{io, path::PathBuf, rc::Rc};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 use concats_core::{
     Repository,
@@ -19,6 +23,7 @@ type HookAgent = &'static dyn concats_hooks::Agent;
 /// Returns an error if the selected subcommand fails.
 pub fn run(cli: Cli) -> miette::Result<()> {
     match cli.command {
+        Some(Commands::Init { path }) => run_init(path.as_deref()),
         Some(Commands::Hook {
             agent,
             event,
@@ -94,13 +99,42 @@ pub fn run_hooks_action(action: HooksAction) -> miette::Result<()> {
     }
 }
 
+fn run_init(path: Option<&Path>) -> miette::Result<()> {
+    let root = concats_hooks::find_worktree_root(path)
+        .map_err(|error| miette::miette!("not inside a git repository: {error}"))?;
+    let binary = concats_hooks::helpers::binary_path().map_err(|e| miette::miette!("{e}"))?;
+
+    let detected: Vec<HookAgent> = all_agents()
+        .iter()
+        .copied()
+        .filter(|agent| agent.is_detected())
+        .collect();
+
+    if detected.is_empty() {
+        return Err(miette::miette!(
+            "no coding agents detected. Install an agent (claude, codex, cursor, ...) \
+             or use `concats hooks install <agent>` to wire up hooks explicitly."
+        ));
+    }
+
+    install_hooks(&detected, &InstallScope::Project { root }, &binary);
+    Ok(())
+}
+
 fn run_hooks_install(agents: &[String], scope: &InstallScope) -> miette::Result<()> {
     let binary = concats_hooks::helpers::binary_path()?;
-    let targets = resolve_agents(agents)?;
-    let mut installed = Vec::new();
+    let targets = agents
+        .iter()
+        .map(|name| resolve_agent(name))
+        .collect::<miette::Result<Vec<_>>>()?;
+    install_hooks(&targets, scope, &binary);
+    Ok(())
+}
 
-    for agent in targets {
-        match agent.install(&binary, scope) {
+fn install_hooks(targets: &[HookAgent], scope: &InstallScope, binary: &Path) {
+    let mut installed = Vec::new();
+    for &agent in targets {
+        match agent.install(binary, scope) {
             Ok(()) => installed.push(agent.name()),
             Err(error) => eprintln!("warning: failed to install hooks for {agent}: {error}"),
         }
@@ -111,7 +145,6 @@ fn run_hooks_install(agents: &[String], scope: &InstallScope) -> miette::Result<
     } else {
         eprintln!("hooks installed for: {}", installed.join(", "));
     }
-    Ok(())
 }
 
 fn run_hooks_uninstall(agents: &[String], scope: &InstallScope) -> miette::Result<()> {
@@ -163,25 +196,6 @@ fn resolve_scope(path: Option<PathBuf>, global: bool) -> miette::Result<InstallS
         .map_or_else(std::env::current_dir, Ok)
         .map_err(|error| miette::miette!("cannot determine cwd: {error}"))?;
     Ok(InstallScope::Project { root })
-}
-
-/// Resolve agent names from CLI args, defaulting to auto-detected agents.
-fn resolve_agents(args: &[String]) -> miette::Result<Vec<HookAgent>> {
-    if args.is_empty() {
-        let detected: Vec<HookAgent> = all_agents()
-            .iter()
-            .copied()
-            .filter(|a| a.is_detected())
-            .collect();
-        if detected.is_empty() {
-            return Err(miette::miette!(
-                "no agents detected. Specify agents explicitly: concats hooks install claude codex ..."
-            ));
-        }
-        Ok(detected)
-    } else {
-        args.iter().map(|name| resolve_agent(name)).collect()
-    }
 }
 
 fn resolve_agent(name: &str) -> miette::Result<HookAgent> {
@@ -443,12 +457,5 @@ mod tests {
     #[test]
     fn resolve_agent_uses_registry_case_insensitively() {
         assert_eq!(resolve_agent("ClAuDe").unwrap().name(), "claude");
-    }
-
-    #[test]
-    fn resolve_agents_preserves_explicit_order() {
-        let agents = resolve_agents(&["copilot".to_string(), "claude".to_string()]).unwrap();
-        let names: Vec<_> = agents.iter().map(|agent| agent.name()).collect();
-        assert_eq!(names, vec!["copilot", "claude"]);
     }
 }

--- a/crates/hooks/src/claude.rs
+++ b/crates/hooks/src/claude.rs
@@ -33,7 +33,7 @@ impl crate::Agent for ClaudeAgent {
                     serde_json::from_str(payload_json).map_err(|error| {
                         Error::session(format!("invalid SessionStart payload: {error}"))
                     })?;
-                let worktree_root = find_worktree_root(payload.cwd.as_deref())?;
+                let worktree_root = find_worktree_root(payload.cwd.as_deref().map(Path::new))?;
                 let repo = Rc::new(Repository::open(&worktree_root)?);
                 handler::on_session_started(repo, &payload.session_id)
             }
@@ -42,7 +42,7 @@ impl crate::Agent for ClaudeAgent {
                     serde_json::from_str(payload_json).map_err(|error| {
                         Error::session(format!("invalid UserPromptSubmit payload: {error}"))
                     })?;
-                let worktree_root = find_worktree_root(payload.cwd.as_deref())?;
+                let worktree_root = find_worktree_root(payload.cwd.as_deref().map(Path::new))?;
                 let repo = Rc::new(Repository::open(&worktree_root)?);
                 handler::on_prompt_submitted(repo, &payload.session_id, "Claude", &payload.prompt)
             }
@@ -51,14 +51,14 @@ impl crate::Agent for ClaudeAgent {
                     serde_json::from_str(payload_json).map_err(|error| {
                         Error::session(format!("invalid PostToolUse payload: {error}"))
                     })?;
-                let worktree_root = find_worktree_root(payload.cwd.as_deref())?;
+                let worktree_root = find_worktree_root(payload.cwd.as_deref().map(Path::new))?;
                 let repo = Rc::new(Repository::open(&worktree_root)?);
                 handler::on_files_changed(repo, &payload.session_id, "Claude")
             }
             "Stop" => {
                 let payload: StopPayload = serde_json::from_str(payload_json)
                     .map_err(|error| Error::session(format!("invalid Stop payload: {error}")))?;
-                let worktree_root = find_worktree_root(payload.cwd.as_deref())?;
+                let worktree_root = find_worktree_root(payload.cwd.as_deref().map(Path::new))?;
                 let repo = Rc::new(Repository::open(&worktree_root)?);
                 let transcript_response = payload
                     .transcript_path
@@ -407,7 +407,7 @@ mod tests {
             init_repo_with_commit(dir.path());
             let sub = dir.path().join("nested/dir");
             std::fs::create_dir_all(&sub).unwrap();
-            let root = crate::find_worktree_root(Some(sub.to_str().unwrap())).unwrap();
+            let root = crate::find_worktree_root(Some(sub.as_path())).unwrap();
             assert_eq!(
                 root.canonicalize().unwrap(),
                 dir.path().canonicalize().unwrap()

--- a/crates/hooks/src/codex.rs
+++ b/crates/hooks/src/codex.rs
@@ -25,7 +25,7 @@ impl crate::Agent for CodexAgent {
         let payload: Payload = serde_json::from_str(payload_json)
             .map_err(|error| Error::session(format!("invalid Codex payload: {error}")))?;
         let session_id = payload.session_id.as_deref().unwrap_or("codex-default");
-        let worktree_root = find_worktree_root(payload.cwd.as_deref())?;
+        let worktree_root = find_worktree_root(payload.cwd.as_deref().map(Path::new))?;
         let repo = Rc::new(Repository::open(&worktree_root)?);
 
         handler::on_files_changed(repo.clone(), session_id, "Codex")?;

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -40,7 +40,7 @@ fn dispatch_simple(
     let payload: HookPayload = serde_json::from_str(payload_json)
         .map_err(|error| Error::session(format!("invalid {agent_name} payload: {error}")))?;
     let session_id = payload.session_id.as_deref().unwrap_or(default_session_id);
-    let worktree_root = find_worktree_root(payload.cwd.as_deref())?;
+    let worktree_root = find_worktree_root(payload.cwd.as_deref().map(Path::new))?;
     let repo = Rc::new(Repository::open(&worktree_root)?);
 
     match resolve(event)? {
@@ -73,9 +73,16 @@ pub enum InstallScope {
     Project { root: PathBuf },
 }
 
-pub(crate) fn find_worktree_root(cwd: Option<&str>) -> Result<PathBuf> {
+/// Resolve the git worktree root from an optional starting directory,
+/// falling back to the process's current directory.
+///
+/// # Errors
+///
+/// Returns an error if the current directory cannot be read, no enclosing
+/// git repository is found, or the repository is bare.
+pub fn find_worktree_root(cwd: Option<&Path>) -> Result<PathBuf> {
     let start = match cwd {
-        Some(dir) => PathBuf::from(dir),
+        Some(dir) => dir.to_path_buf(),
         None => std::env::current_dir()?,
     };
     let repo = git2::Repository::discover(&start)?;


### PR DESCRIPTION
Split the "set up concats in this repo" flow out of `hooks install` and into its own top-level verb, matching how `git init`, `cargo init`, and most CLIs separate first-run setup from ongoing management.

- `concats init [--path <PATH>]` resolves the enclosing git worktree, auto-detects installed agents, and installs their hooks at the project level. No `--global` flag: users wanting user-level hooks run `concats hooks install <agent> --global` explicitly.
- `concats hooks install` now requires at least one agent (clap- enforced). The no-args auto-detect branch is gone — users are pointed at `concats init` for the "install everything" case.
- `hooks install/uninstall/status` stay as the targeted management surface for one named agent at a time.

`find_worktree_root` is now `pub` and takes `Option<&Path>` so the CLI crate can reuse it without pulling in `git2`. Internal call sites in claude and codex hooks adopt the new signature.