### PR TITLE
Add hooks handler for gemini-antigravity

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -56,8 +56,26 @@ pub enum Commands {
         workspace: Option<PathBuf>,
     },
 
-    /// List recorded sessions.
+    /// List recorded sessions. With a ref, list sessions reaching that ref.
     Sessions {
+        /// Optional commit, branch, tag, or HEAD-ish to filter by.
+        #[arg(name = "ref")]
+        session_ref: Option<String>,
+
+        /// Workspace root directory (defaults to current directory).
+        #[arg(short, long)]
+        workspace: Option<PathBuf>,
+    },
+
+    /// Rewrite session refs in response to a git post-rewrite hook.
+    ///
+    /// Reads `<old> <new>` pairs from stdin and updates every affected session
+    /// and snapshot ref so their parent pointers stay live after rebases.
+    #[command(hide = true)]
+    Rewrite {
+        /// Rewrite kind passed by git (`rebase` or `amend`).
+        kind: Option<String>,
+
         /// Workspace root directory (defaults to current directory).
         #[arg(short, long)]
         workspace: Option<PathBuf>,

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -83,7 +83,7 @@ pub enum Commands {
 
     /// Handle an agent hook event (reads JSON from stdin unless --payload is given).
     Hook {
-        /// The agent (claude, codex, cursor, windsurf, gemini, copilot, droid, amp, opencode).
+        /// The agent (claude, codex, cursor, windsurf, gemini, gemini-antigravity, copilot, droid, amp, opencode).
         agent: String,
 
         /// Hook event name (agent-specific). Optional for single-event agents like Codex.

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,16 +1,18 @@
 use std::{
-    io,
+    collections::HashMap,
+    io::{self, BufRead},
     path::{Path, PathBuf},
     rc::Rc,
 };
 
 use concats_core::{
-    Repository,
+    Oid, Repository,
     diff::{self, DiffStatus},
+    rewrite,
     session::{self, Session},
     turn::{self, Turn, TurnEntryKind},
 };
-use concats_hooks::{InstallScope, all_agents, find_agent};
+use concats_hooks::{InstallScope, all_agents, find_agent, git_hook};
 
 use crate::cli::{Cli, Commands, HooksAction};
 
@@ -41,7 +43,11 @@ pub fn run(cli: Cli) -> miette::Result<()> {
             quiet,
             workspace,
         }) => run_checkout(&session_ref, force, quiet, workspace),
-        Some(Commands::Sessions { workspace }) => run_sessions_list(workspace),
+        Some(Commands::Sessions {
+            session_ref,
+            workspace,
+        }) => run_sessions_list(session_ref.as_deref(), workspace),
+        Some(Commands::Rewrite { kind, workspace }) => run_rewrite(kind.as_deref(), workspace),
         None => {
             use clap::CommandFactory;
             Cli::command()
@@ -117,8 +123,38 @@ fn run_init(path: Option<&Path>) -> miette::Result<()> {
         ));
     }
 
-    install_hooks(&detected, &InstallScope::Project { root }, &binary);
+    install_hooks(
+        &detected,
+        &InstallScope::Project { root: root.clone() },
+        &binary,
+    );
+    install_post_rewrite_hook(&root, &binary);
     Ok(())
+}
+
+fn install_post_rewrite_hook(worktree_root: &Path, binary: &Path) {
+    let Ok(repo) = git2::Repository::discover(worktree_root) else {
+        eprintln!("warning: could not locate git directory for post-rewrite hook");
+        return;
+    };
+    // NOTE: For linked worktrees, repo.path() returns
+    // .git/worktrees/<name>/, but git executes hooks from the common gitdir.
+    // commondir() points at the shared directory in both regular and linked
+    // worktrees.
+    match git_hook::install(repo.commondir(), binary) {
+        Ok(git_hook::HookStatus::Managed) => {
+            eprintln!("post-rewrite hook installed");
+        }
+        Ok(git_hook::HookStatus::Foreign) => {
+            eprintln!(
+                "warning: .git/hooks/post-rewrite exists and is not managed by concats;\n  \
+                 add `exec {} rewrite \"$@\"` to it so rebases update session refs",
+                binary.display()
+            );
+        }
+        Ok(git_hook::HookStatus::Missing) => {}
+        Err(error) => eprintln!("warning: failed to install post-rewrite hook: {error}"),
+    }
 }
 
 fn run_hooks_install(agents: &[String], scope: &InstallScope) -> miette::Result<()> {
@@ -210,12 +246,22 @@ fn unknown_agent_error(name: &str) -> miette::Report {
     )
 }
 
-fn run_sessions_list(workspace: Option<PathBuf>) -> miette::Result<()> {
+fn run_sessions_list(filter_ref: Option<&str>, workspace: Option<PathBuf>) -> miette::Result<()> {
     let repo = open_repo(workspace)?;
-    let sessions = session::list(&repo).map_err(|e| miette::miette!("{e}"))?;
+    let sessions = match filter_ref {
+        Some(input) => {
+            let oid = revparse_oid(&repo, input)?;
+            session::containing(&repo, oid).map_err(|e| miette::miette!("{e}"))?
+        }
+        None => session::list(&repo).map_err(|e| miette::miette!("{e}"))?,
+    };
 
     if sessions.is_empty() {
-        println!("no sessions");
+        if filter_ref.is_some() {
+            println!("no sessions reaching the given ref");
+        } else {
+            println!("no sessions");
+        }
         return Ok(());
     }
 
@@ -236,6 +282,65 @@ fn run_sessions_list(workspace: Option<PathBuf>) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// concats rewrite (post-rewrite hook)
+// ---------------------------------------------------------------------------
+
+fn run_rewrite(_kind: Option<&str>, workspace: Option<PathBuf>) -> miette::Result<()> {
+    let rewrites = parse_rewrite_pairs(io::stdin().lock())?;
+    if rewrites.is_empty() {
+        return Ok(());
+    }
+
+    let repo = open_repo(workspace)?;
+    let report = rewrite::apply(&repo, &rewrites).map_err(|e| miette::miette!("{e}"))?;
+
+    for update in &report.sessions {
+        eprintln!(
+            "rewrote {} ({} -> {})",
+            update.name,
+            update.old_tip.short(),
+            update.new_tip.short()
+        );
+    }
+    for update in &report.snapshots {
+        eprintln!(
+            "rewrote {} ({} -> {})",
+            update.name,
+            update.old_tip.short(),
+            update.new_tip.short()
+        );
+    }
+    for dropped in &report.dropped_anchors {
+        eprintln!(
+            "warning: turn {} still anchors on orphaned commit {}",
+            dropped.turn.short(),
+            dropped.parent.short()
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_rewrite_pairs<R: BufRead>(reader: R) -> miette::Result<HashMap<Oid, Oid>> {
+    let mut pairs = HashMap::new();
+    for line in reader.lines() {
+        let line = line.map_err(|e| miette::miette!("failed to read stdin: {e}"))?;
+        let mut parts = line.split_whitespace();
+        let (Some(old), Some(new)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let old_oid: Oid = old
+            .parse()
+            .map_err(|e| miette::miette!("invalid old OID '{old}': {e}"))?;
+        let new_oid: Oid = new
+            .parse()
+            .map_err(|e| miette::miette!("invalid new OID '{new}': {e}"))?;
+        pairs.insert(old_oid, new_oid);
+    }
+    Ok(pairs)
 }
 
 // ---------------------------------------------------------------------------
@@ -402,13 +507,15 @@ fn resolve_session_ref(repo: &Rc<Repository>, input: &str) -> miette::Result<Res
         });
     }
 
-    // Bare SHA prefix — search across all sessions.
     if offset > 0 {
         return Err(miette::miette!(
             "session '{name}' not found (tilde suffix only works with session names)"
         ));
     }
 
+    // Bare SHA prefix — search across all sessions. Runs before the revparse
+    // fallback so an explicit turn SHA always resolves to the requested turn,
+    // not to its enclosing session's tip.
     let sessions = session::list(repo).map_err(|e| miette::miette!("{e}"))?;
     for session in &sessions {
         let Ok(turns) = turn::list(session) else {
@@ -425,7 +532,32 @@ fn resolve_session_ref(repo: &Rc<Repository>, input: &str) -> miette::Result<Res
         }
     }
 
+    // Try git revparse (branch, tag, HEAD-ish, full non-turn SHA) — if it
+    // resolves and a session reaches it, use the newest such session's tip.
+    if let Ok(oid) = revparse_oid(repo, input)
+        && let Ok(sessions) = session::containing(repo, oid)
+        && let Some(session) = sessions.into_iter().next()
+        && let Ok(turns) = turn::list(&session)
+        && let Some(turn) = turns.last().cloned()
+    {
+        return Ok(ResolvedRef {
+            session,
+            turn,
+            offset_from_tip: 0,
+        });
+    }
+
     Err(miette::miette!("no session or turn matching '{input}'"))
+}
+
+fn revparse_oid(repo: &Repository, input: &str) -> miette::Result<Oid> {
+    let object = repo
+        .revparse_single(input)
+        .map_err(|e| miette::miette!("cannot resolve '{input}': {e}"))?;
+    let commit = object
+        .peel_to_commit()
+        .map_err(|e| miette::miette!("'{input}' does not resolve to a commit: {e}"))?;
+    Ok(Oid::from(commit.id()))
 }
 
 /// Parse "session-a~3" → ("session-a", 3), "session-a~2~1" → ("session-a", 3).
@@ -457,5 +589,45 @@ mod tests {
     #[test]
     fn resolve_agent_uses_registry_case_insensitively() {
         assert_eq!(resolve_agent("ClAuDe").unwrap().name(), "claude");
+    }
+
+    #[test]
+    fn parse_rewrite_pairs_accepts_amend_and_rebase_lines() {
+        // post-rewrite emits `old new` for amend and `old new [extra]` for rebase.
+        let input = "\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n\
+            cccccccccccccccccccccccccccccccccccccccc dddddddddddddddddddddddddddddddddddddddd extra\n\
+        ";
+        let pairs = parse_rewrite_pairs(input.as_bytes()).unwrap();
+        assert_eq!(pairs.len(), 2);
+        assert!(
+            pairs.contains_key(
+                &"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .parse::<Oid>()
+                    .unwrap()
+            )
+        );
+        assert!(
+            pairs.contains_key(
+                &"cccccccccccccccccccccccccccccccccccccccc"
+                    .parse::<Oid>()
+                    .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn parse_rewrite_pairs_ignores_blank_and_incomplete_lines() {
+        let input = "\n   \nonlyone\n\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n\
+            ";
+        let pairs = parse_rewrite_pairs(input.as_bytes()).unwrap();
+        assert_eq!(pairs.len(), 1);
+    }
+
+    #[test]
+    fn parse_rewrite_pairs_rejects_malformed_oids() {
+        let input = "not-an-oid also-not-an-oid\n";
+        assert!(parse_rewrite_pairs(input.as_bytes()).is_err());
     }
 }

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -5,7 +5,7 @@ use time::{OffsetDateTime, UtcOffset};
 use crate::error::{Error, Result};
 
 /// An opaque commit identifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Oid(git2::Oid);
 
 impl Oid {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod diff;
 pub mod error;
+pub mod rewrite;
 pub mod session;
 pub mod snapshot;
 pub mod turn;

--- a/crates/core/src/rewrite.rs
+++ b/crates/core/src/rewrite.rs
@@ -1,0 +1,252 @@
+//! Rebase-aware rewriting of session and snapshot chains.
+//!
+//! When branch history is rewritten (`git rebase`, `git commit --amend`), turn
+//! commits whose parents referenced the old SHAs are left anchored to orphans.
+//! [`apply`] mirrors the rewrite onto `refs/agent/sessions/*` and
+//! `refs/agent/snapshots/*` so the graph stays connected to the live branch.
+
+use std::{
+    collections::HashMap,
+    hash::{BuildHasher, RandomState},
+    rc::Rc,
+};
+
+use crate::{
+    error::Result,
+    git::Oid,
+    session::{self, Session},
+    snapshot,
+    turn::{self, Turn},
+};
+
+/// A single ref update performed during [`apply`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdatedRef {
+    pub name: String,
+    pub old_tip: Oid,
+    pub new_tip: Oid,
+}
+
+/// A turn whose parents include commits missing from the rewrite map.
+///
+/// Typically an interactive rebase that dropped a commit outright: the anchor
+/// has no replacement, so the turn keeps pointing at the orphaned commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DroppedAnchor {
+    pub turn: Oid,
+    pub parent: Oid,
+}
+
+/// Outcome of a rewrite pass.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RewriteReport {
+    pub sessions: Vec<UpdatedRef>,
+    pub snapshots: Vec<UpdatedRef>,
+    pub dropped_anchors: Vec<DroppedAnchor>,
+}
+
+/// Apply a commit rewrite map to every session and snapshot ref.
+///
+/// The map is typically produced by a `post-rewrite` git hook. Each session's
+/// turns are reconstructed base-to-tip so downstream turns see the new parent 0
+/// from the previous turn in the same pass. Trees, authors, committers, and
+/// commit messages are preserved verbatim; only parents are remapped.
+///
+/// # Errors
+///
+/// Returns an error if session or snapshot refs cannot be enumerated, commits
+/// cannot be loaded or written, or ref updates fail.
+pub fn apply<S: BuildHasher>(
+    repo: &Rc<git2::Repository>,
+    initial: &HashMap<Oid, Oid, S>,
+) -> Result<RewriteReport> {
+    let mut report = RewriteReport::default();
+    if initial.is_empty() {
+        return Ok(report);
+    }
+
+    let mut map: HashMap<Oid, Oid, RandomState> = initial.iter().map(|(k, v)| (*k, *v)).collect();
+
+    for session in session::list(repo)? {
+        rewrite_session(&session, &mut map, &mut report)?;
+    }
+
+    for session in session::list(repo)? {
+        rewrite_snapshots(&session, &map, &mut report)?;
+    }
+
+    Ok(report)
+}
+
+fn rewrite_session(
+    session: &Session,
+    map: &mut HashMap<Oid, Oid>,
+    report: &mut RewriteReport,
+) -> Result<()> {
+    let turns = turn::list(session)?;
+    if turns.is_empty() {
+        return Ok(());
+    }
+
+    let repo = session.repo();
+    let original_tip = turns
+        .last()
+        .map(|turn| turn.oid)
+        .expect("turns is non-empty");
+    let mut new_tip = original_tip;
+    let mut changed = false;
+
+    for turn in &turns {
+        let commit = repo.find_commit(turn.oid.as_git())?;
+        let original_parents: Vec<Oid> = commit.parent_ids().map(Oid::from).collect();
+        let new_parents: Vec<Oid> = original_parents
+            .iter()
+            .map(|parent| map.get(parent).copied().unwrap_or(*parent))
+            .collect();
+
+        if new_parents == original_parents {
+            new_tip = turn.oid;
+            continue;
+        }
+
+        record_dropped(turn, &original_parents, map, report);
+
+        let new_oid = write_with_parents(repo, &commit, &new_parents)?;
+        map.insert(turn.oid, Oid::from(new_oid));
+        new_tip = Oid::from(new_oid);
+        changed = true;
+    }
+
+    if !changed {
+        return Ok(());
+    }
+
+    let ref_name = session::ref_name(&session.id);
+    repo.reference(
+        &ref_name,
+        new_tip.as_git(),
+        true,
+        "concats rewrite: post-rewrite",
+    )?;
+    report.sessions.push(UpdatedRef {
+        name: ref_name,
+        old_tip: original_tip,
+        new_tip,
+    });
+
+    Ok(())
+}
+
+fn rewrite_snapshots(
+    session: &Session,
+    map: &HashMap<Oid, Oid>,
+    report: &mut RewriteReport,
+) -> Result<()> {
+    let snapshots = snapshot::list(session)?;
+    if snapshots.is_empty() {
+        return Ok(());
+    }
+
+    let repo = session.repo();
+    let original_tip = snapshots
+        .last()
+        .map(|snap| snap.oid)
+        .expect("snapshots is non-empty");
+    let mut prev_rewrite: Option<Oid> = None;
+    let mut new_tip = original_tip;
+    let mut changed = false;
+
+    for snap in &snapshots {
+        let commit = repo.find_commit(snap.oid.as_git())?;
+        let original_parents: Vec<Oid> = commit.parent_ids().map(Oid::from).collect();
+        let new_parents: Vec<Oid> = match original_parents.len() {
+            1 => vec![
+                map.get(&original_parents[0])
+                    .copied()
+                    .unwrap_or(original_parents[0]),
+            ],
+            2 => {
+                let prev_parent = prev_rewrite.unwrap_or(original_parents[0]);
+                let turn_parent = map
+                    .get(&original_parents[1])
+                    .copied()
+                    .unwrap_or(original_parents[1]);
+                vec![prev_parent, turn_parent]
+            }
+            _ => original_parents.clone(),
+        };
+
+        if new_parents == original_parents {
+            prev_rewrite = Some(snap.oid);
+            new_tip = snap.oid;
+            continue;
+        }
+
+        let new_oid = write_with_parents(repo, &commit, &new_parents)?;
+        prev_rewrite = Some(Oid::from(new_oid));
+        new_tip = Oid::from(new_oid);
+        changed = true;
+    }
+
+    if !changed {
+        return Ok(());
+    }
+
+    let ref_name = snapshot::ref_name(&session.id);
+    repo.reference(
+        &ref_name,
+        new_tip.as_git(),
+        true,
+        "concats rewrite: post-rewrite",
+    )?;
+    report.snapshots.push(UpdatedRef {
+        name: ref_name,
+        old_tip: original_tip,
+        new_tip,
+    });
+
+    Ok(())
+}
+
+fn write_with_parents(
+    repo: &git2::Repository,
+    commit: &git2::Commit<'_>,
+    parents: &[Oid],
+) -> Result<git2::Oid> {
+    let parent_commits: Vec<git2::Commit<'_>> = parents
+        .iter()
+        .map(|oid| repo.find_commit(oid.as_git()))
+        .collect::<std::result::Result<_, _>>()?;
+    let parent_refs: Vec<&git2::Commit<'_>> = parent_commits.iter().collect();
+    let tree = commit.tree()?;
+    let author = commit.author();
+    let committer = commit.committer();
+    Ok(repo.commit(
+        None,
+        &author,
+        &committer,
+        commit.message_raw().unwrap_or(""),
+        &tree,
+        &parent_refs,
+    )?)
+}
+
+fn record_dropped(
+    turn: &Turn,
+    parents: &[Oid],
+    map: &HashMap<Oid, Oid>,
+    report: &mut RewriteReport,
+) {
+    for parent in parents {
+        if map.contains_key(parent) {
+            continue;
+        }
+        // NOTE: The parent was not in the rewrite map. When the turn is still
+        // being rewritten (because another parent was remapped), surface this
+        // parent as a potentially-dropped anchor so callers can warn the user.
+        report.dropped_anchors.push(DroppedAnchor {
+            turn: turn.oid,
+            parent: *parent,
+        });
+    }
+}

--- a/crates/core/tests/rewrite.rs
+++ b/crates/core/tests/rewrite.rs
@@ -1,0 +1,387 @@
+pub mod support;
+
+use std::{collections::HashMap, rc::Rc};
+
+use concats_core::{
+    Oid, rewrite, session,
+    snapshot::{self, SnapshotReason},
+    turn,
+};
+
+fn simulate_rebase(
+    repo: &git2::Repository,
+    worktree: &std::path::Path,
+    commits: &[(&str, &str)],
+    base: Oid,
+) -> Vec<(Oid, Oid)> {
+    // Replay the rebase: from `base`, recreate each commit with a fresh tree and
+    // a bumped committer timestamp so the new SHAs differ.
+    let original_head = Oid::from(repo.head().unwrap().target().unwrap());
+    let mut pairs = Vec::new();
+    // Walk original history from base..HEAD collecting the original OIDs.
+    let mut revwalk = repo.revwalk().unwrap();
+    revwalk.push(original_head.as_git()).unwrap();
+    revwalk.hide(base.as_git()).unwrap();
+    let mut original: Vec<git2::Oid> = revwalk
+        .filter_map(std::result::Result::ok)
+        .collect::<Vec<_>>();
+    original.reverse();
+
+    // Reset HEAD to base, then recommit each original commit with updated timestamps.
+    let base_commit = repo.find_commit(base.as_git()).unwrap();
+    repo.reference("refs/heads/master", base.as_git(), true, "rebase reset")
+        .ok();
+    repo.set_head_detached(base.as_git()).unwrap();
+    let mut checkout = git2::build::CheckoutBuilder::new();
+    checkout.force();
+    repo.checkout_head(Some(&mut checkout)).unwrap();
+
+    let mut parent_commit = base_commit;
+    for (i, old_oid) in original.iter().enumerate() {
+        let (file_name, contents) = commits[i];
+        std::fs::write(worktree.join(file_name), contents).unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_all(["*"], git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        index.write().unwrap();
+        let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+        // Bump timestamp to force new SHA.
+        let sig = git2::Signature::new(
+            "test",
+            "test@test",
+            &git2::Time::new(2_000_000_000 + i64::try_from(i).unwrap(), 0),
+        )
+        .unwrap();
+        let new_oid = repo
+            .commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                &format!("rebased {file_name}"),
+                &tree,
+                &[&parent_commit],
+            )
+            .unwrap();
+        pairs.push((Oid::from(*old_oid), Oid::from(new_oid)));
+        parent_commit = repo.find_commit(new_oid).unwrap();
+    }
+    pairs
+}
+
+#[test]
+fn linear_rebase_rewrites_all_turns() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Rc::new(support::init_repo_with_commit(dir.path()));
+    let base = Oid::from(repo.head().unwrap().target().unwrap());
+
+    let anchor_a = support::commit_head(&repo, dir.path(), "a.txt", "A");
+    let session = session::create(repo.clone(), "session-a", anchor_a).unwrap();
+    let turn1 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    let _anchor_b = support::commit_head(&repo, dir.path(), "b.txt", "B");
+    let turn2 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    let anchor_c = support::commit_head(&repo, dir.path(), "c.txt", "C");
+    let turn3 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+
+    let pairs = simulate_rebase(
+        &repo,
+        dir.path(),
+        &[("a.txt", "A+"), ("b.txt", "B+"), ("c.txt", "C+")],
+        base,
+    );
+    let map: HashMap<Oid, Oid> = pairs.iter().copied().collect();
+    let new_c = map[&anchor_c];
+
+    let report = rewrite::apply(&repo, &map).unwrap();
+
+    assert_eq!(report.sessions.len(), 1);
+    assert!(report.dropped_anchors.is_empty());
+
+    let reloaded = session::open(repo.clone(), "session-a").unwrap();
+    let turns = turn::list(&reloaded).unwrap();
+    assert_eq!(turns.len(), 3);
+    assert_ne!(turns[0].oid, turn1.oid);
+    assert_ne!(turns[1].oid, turn2.oid);
+    assert_ne!(turns[2].oid, turn3.oid);
+
+    let tip_commit = repo.find_commit(turns[2].oid.as_git()).unwrap();
+    assert_eq!(tip_commit.parent_id(1).unwrap(), new_c.as_git());
+
+    assert!(session::containing(&repo, new_c).unwrap().len() == 1);
+}
+
+#[test]
+fn amend_rewrites_only_affected_turns() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Rc::new(support::init_repo_with_commit(dir.path()));
+
+    let anchor_a = support::commit_head(&repo, dir.path(), "a.txt", "A");
+    let session = session::create(repo.clone(), "session-a", anchor_a).unwrap();
+    let turn1 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    let anchor_b = support::commit_head(&repo, dir.path(), "b.txt", "B");
+    let turn2 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+
+    // Amend only anchor B.
+    let new_b_commit = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_000, 0)).unwrap();
+        let parent = repo.find_commit(anchor_a.as_git()).unwrap();
+        let tree = parent.tree().unwrap();
+        repo.commit(None, &sig, &sig, "amended", &tree, &[&parent])
+            .unwrap()
+    };
+    let new_b = Oid::from(new_b_commit);
+
+    let mut map = HashMap::new();
+    map.insert(anchor_b, new_b);
+
+    let report = rewrite::apply(&repo, &map).unwrap();
+    assert_eq!(report.sessions.len(), 1);
+
+    let reloaded = session::open(repo.clone(), "session-a").unwrap();
+    let turns = turn::list(&reloaded).unwrap();
+    // turn1 had parent anchor_a (unmapped, unchanged): unchanged SHA.
+    assert_eq!(turns[0].oid, turn1.oid);
+    // turn2 had parent anchor_b: rewritten.
+    assert_ne!(turns[1].oid, turn2.oid);
+    let tip_commit = repo.find_commit(turns[1].oid.as_git()).unwrap();
+    assert_eq!(tip_commit.parent_id(0).unwrap(), turn1.oid.as_git());
+    assert_eq!(tip_commit.parent_id(1).unwrap(), new_b.as_git());
+
+    // Running again with the same (now stale) map is a no-op.
+    let second = rewrite::apply(&repo, &map).unwrap();
+    assert!(second.sessions.is_empty());
+    assert!(second.snapshots.is_empty());
+}
+
+#[test]
+fn dropped_anchor_is_reported_and_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Rc::new(support::init_repo_with_commit(dir.path()));
+
+    let anchor_a = support::commit_head(&repo, dir.path(), "a.txt", "A");
+    let session = session::create(repo.clone(), "session-a", anchor_a).unwrap();
+    let _turn1 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    let anchor_b = support::commit_head(&repo, dir.path(), "b.txt", "B");
+    let _turn2 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    let anchor_c = support::commit_head(&repo, dir.path(), "c.txt", "C");
+    let _turn3 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+
+    // Simulate: anchor_b is dropped (absent from map); a and c are rewritten.
+    let new_a = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_100, 0)).unwrap();
+        let parent = repo
+            .find_commit(Oid::from(repo.head().unwrap().target().unwrap()).as_git())
+            .unwrap();
+        // Build a synthetic predecessor as a new root for mapping purposes.
+        // For this test we only need a distinct OID, reuse the tree.
+        let tree = parent.tree().unwrap();
+        Oid::from(repo.commit(None, &sig, &sig, "new a", &tree, &[]).unwrap())
+    };
+    let new_c = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_200, 0)).unwrap();
+        let parent = repo.find_commit(new_a.as_git()).unwrap();
+        let tree = parent.tree().unwrap();
+        Oid::from(
+            repo.commit(None, &sig, &sig, "new c", &tree, &[&parent])
+                .unwrap(),
+        )
+    };
+
+    let mut map = HashMap::new();
+    map.insert(anchor_a, new_a);
+    map.insert(anchor_c, new_c);
+
+    let report = rewrite::apply(&repo, &map).unwrap();
+
+    assert_eq!(report.sessions.len(), 1);
+    // turn2's parent anchor_b was not in the map — reported as dropped.
+    assert!(
+        report
+            .dropped_anchors
+            .iter()
+            .any(|drop| drop.parent == anchor_b),
+        "expected dropped anchor for B, got {:?}",
+        report.dropped_anchors
+    );
+
+    let reloaded = session::open(repo.clone(), "session-a").unwrap();
+    let turns = turn::list(&reloaded).unwrap();
+    assert_eq!(turns.len(), 3);
+    // turn2 keeps anchor_b (orphaned) as parent 1.
+    let turn2_commit = repo.find_commit(turns[1].oid.as_git()).unwrap();
+    assert_eq!(turn2_commit.parent_id(1).unwrap(), anchor_b.as_git());
+}
+
+#[test]
+fn concurrent_sessions_sharing_anchor_both_update() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Rc::new(support::init_repo_with_commit(dir.path()));
+
+    let anchor = support::commit_head(&repo, dir.path(), "a.txt", "A");
+    let session_a = session::create(repo.clone(), "session-a", anchor).unwrap();
+    let _ta = session::commit(&session_a, &support::turn_message("session-a")).unwrap();
+    let session_b = session::create(repo.clone(), "session-b", anchor).unwrap();
+    let _tb = session::commit(&session_b, &support::turn_message("session-b")).unwrap();
+
+    // Synthesize a new anchor.
+    let new_anchor = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_300, 0)).unwrap();
+        let parent = repo
+            .find_commit(Oid::from(repo.head().unwrap().target().unwrap()).as_git())
+            .unwrap();
+        let tree = parent.tree().unwrap();
+        Oid::from(
+            repo.commit(None, &sig, &sig, "new anchor", &tree, &[])
+                .unwrap(),
+        )
+    };
+
+    let mut map = HashMap::new();
+    map.insert(anchor, new_anchor);
+
+    let report = rewrite::apply(&repo, &map).unwrap();
+    assert_eq!(report.sessions.len(), 2);
+
+    for name in ["session-a", "session-b"] {
+        let reloaded = session::open(repo.clone(), name).unwrap();
+        let turns = turn::list(&reloaded).unwrap();
+        let tip = repo.find_commit(turns[0].oid.as_git()).unwrap();
+        // First turn in each session now anchors on the new commit.
+        assert_eq!(tip.parent_id(0).unwrap(), new_anchor.as_git());
+    }
+}
+
+#[test]
+fn snapshot_chain_is_rewritten_when_turns_change() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Rc::new(support::init_repo_with_commit(dir.path()));
+
+    let anchor = support::commit_head(&repo, dir.path(), "a.txt", "A");
+    let session = session::create(repo.clone(), "session-a", anchor).unwrap();
+
+    let turn1 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    snapshot::capture(&session, turn1.oid, SnapshotReason::TurnCommit).unwrap();
+    std::fs::write(dir.path().join("changed.txt"), "hello").unwrap();
+    let turn2 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    snapshot::capture(&session, turn2.oid, SnapshotReason::TurnCommit).unwrap();
+
+    // Synthesize a new anchor.
+    let new_anchor = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_400, 0)).unwrap();
+        let parent = repo.find_commit(anchor.as_git()).unwrap();
+        let tree = parent.tree().unwrap();
+        Oid::from(
+            repo.commit(None, &sig, &sig, "new anchor", &tree, &[])
+                .unwrap(),
+        )
+    };
+
+    let mut map = HashMap::new();
+    map.insert(anchor, new_anchor);
+
+    let report = rewrite::apply(&repo, &map).unwrap();
+    assert_eq!(report.sessions.len(), 1);
+    assert_eq!(report.snapshots.len(), 1);
+
+    let reloaded = session::open(repo.clone(), "session-a").unwrap();
+    let turns = turn::list(&reloaded).unwrap();
+    assert_eq!(turns.len(), 2);
+    let snap_for_turn2 = snapshot::get(&reloaded, turns[1].oid).unwrap();
+    let snap_commit = repo.find_commit(snap_for_turn2.oid.as_git()).unwrap();
+    assert_eq!(snap_commit.parent_count(), 2);
+    // parent 1 points at rewritten turn2.
+    assert_eq!(snap_commit.parent_id(1).unwrap(), turns[1].oid.as_git());
+    // First snapshot's parent 0 is the rewritten turn1.
+    let snap_for_turn1 = snapshot::get(&reloaded, turns[0].oid).unwrap();
+    let snap1_commit = repo.find_commit(snap_for_turn1.oid.as_git()).unwrap();
+    assert_eq!(snap1_commit.parent_count(), 1);
+    assert_eq!(snap1_commit.parent_id(0).unwrap(), turns[0].oid.as_git());
+}
+
+#[test]
+fn irrelevant_rewrite_is_no_op() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Rc::new(support::init_repo_with_commit(dir.path()));
+
+    let anchor = support::commit_head(&repo, dir.path(), "a.txt", "A");
+    let session = session::create(repo.clone(), "session-a", anchor).unwrap();
+    let original_turn = session::commit(&session, &support::turn_message("session-a")).unwrap();
+
+    // Map keys that no session references.
+    let unrelated_old = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_500, 0)).unwrap();
+        let parent = repo.find_commit(anchor.as_git()).unwrap();
+        let tree = parent.tree().unwrap();
+        Oid::from(
+            repo.commit(None, &sig, &sig, "unrelated old", &tree, &[])
+                .unwrap(),
+        )
+    };
+    let unrelated_new = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_600, 0)).unwrap();
+        let parent = repo.find_commit(anchor.as_git()).unwrap();
+        let tree = parent.tree().unwrap();
+        Oid::from(
+            repo.commit(None, &sig, &sig, "unrelated new", &tree, &[])
+                .unwrap(),
+        )
+    };
+
+    let mut map = HashMap::new();
+    map.insert(unrelated_old, unrelated_new);
+
+    let report = rewrite::apply(&repo, &map).unwrap();
+    assert!(report.sessions.is_empty());
+    assert!(report.snapshots.is_empty());
+    assert!(report.dropped_anchors.is_empty());
+
+    // Session tip unchanged.
+    let reloaded = session::open(repo.clone(), "session-a").unwrap();
+    assert_eq!(session::tip(&reloaded).unwrap(), original_turn.oid);
+}
+
+#[test]
+fn first_turn_with_single_parent_anchor_is_rewritten() {
+    // Session where first turn's parent 0 IS the anchor (HEAD == base at turn time).
+    let dir = tempfile::tempdir().unwrap();
+    let repo = Rc::new(support::init_repo_with_commit(dir.path()));
+    let base = Oid::from(repo.head().unwrap().target().unwrap());
+
+    let session = session::create(repo.clone(), "session-a", base).unwrap();
+    let turn1 = session::commit(&session, &support::turn_message("session-a")).unwrap();
+    // First-turn sanity: single parent pointing at base.
+    let t1_commit = repo.find_commit(turn1.oid.as_git()).unwrap();
+    assert_eq!(t1_commit.parent_count(), 1);
+    assert_eq!(t1_commit.parent_id(0).unwrap(), base.as_git());
+
+    // Rewrite the base.
+    let new_base = {
+        let sig =
+            git2::Signature::new("test", "test@test", &git2::Time::new(2_000_000_700, 0)).unwrap();
+        let parent = repo.find_commit(base.as_git()).unwrap();
+        let tree = parent.tree().unwrap();
+        Oid::from(
+            repo.commit(None, &sig, &sig, "new base", &tree, &[])
+                .unwrap(),
+        )
+    };
+
+    let mut map = HashMap::new();
+    map.insert(base, new_base);
+
+    let report = rewrite::apply(&repo, &map).unwrap();
+    assert_eq!(report.sessions.len(), 1);
+
+    let reloaded = session::open(repo.clone(), "session-a").unwrap();
+    let turns = turn::list(&reloaded).unwrap();
+    let new_t1 = repo.find_commit(turns[0].oid.as_git()).unwrap();
+    assert_eq!(new_t1.parent_count(), 1);
+    assert_eq!(new_t1.parent_id(0).unwrap(), new_base.as_git());
+}

--- a/crates/hooks/src/gemini_antigravity.rs
+++ b/crates/hooks/src/gemini_antigravity.rs
@@ -1,0 +1,196 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use concats_core::error::{Error, Result};
+
+use crate::{HandlerAction, InstallScope, json_config};
+
+const AGENT: &str = "gemini-antigravity";
+const MATCHER: &str = "write_file|replace";
+
+pub(crate) struct GeminiAntigravityAgent;
+
+impl crate::Agent for GeminiAntigravityAgent {
+    fn name(&self) -> &'static str {
+        AGENT
+    }
+
+    fn is_detected(&self) -> bool {
+        dirs::home_dir().is_some_and(|home| home.join(".gemini").join("antigravity").is_dir())
+    }
+
+    fn dispatch(&self, event: Option<&str>, payload_json: &str) -> Result<()> {
+        let event =
+            event.ok_or_else(|| Error::session(format!("{AGENT} requires an event name")))?;
+        crate::dispatch_simple(
+            "Gemini Antigravity",
+            "gemini-antigravity-default",
+            event,
+            payload_json,
+            |event| match event {
+                "AfterTool" | "BeforeTool" => Ok(HandlerAction::FilesChanged),
+                _ => Err(Error::session(format!(
+                    "unknown Gemini Antigravity hook event: {event}"
+                ))),
+            },
+        )
+    }
+
+    fn install(&self, binary: &Path, scope: &InstallScope) -> Result<()> {
+        let _ = scope;
+        json_config::apply(&config_path()?, |value| install_hooks(value, binary))
+    }
+
+    fn uninstall(&self, scope: &InstallScope) -> Result<()> {
+        let _ = scope;
+        let path = config_path()?;
+        if !path.exists() {
+            return Ok(());
+        }
+        json_config::apply(&path, |v| Ok(remove_hooks(v)))
+    }
+
+    fn is_installed(&self, scope: &InstallScope) -> bool {
+        let _ = scope;
+        config_path().ok().is_some_and(|path| {
+            fs::read_to_string(path)
+                .is_ok_and(|data| data.contains(&format!("concats hook {AGENT}")))
+        })
+    }
+}
+
+fn config_path() -> Result<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(".gemini").join("antigravity").join("settings.json"))
+        .ok_or_else(|| Error::session("cannot determine home directory"))
+}
+
+fn install_hooks(mut value: serde_json::Value, binary: &Path) -> Result<serde_json::Value> {
+    let root = value
+        .as_object_mut()
+        .ok_or_else(|| Error::session("gemini-antigravity config root is not an object"))?;
+
+    let tools = root
+        .entry("tools")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| Error::session("gemini-antigravity tools is not an object"))?;
+    tools.insert("enableHooks".into(), serde_json::json!(true));
+
+    let command_prefix = format!("concats hook {AGENT}");
+    let hooks = root
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| Error::session("gemini-antigravity hooks is not an object"))?;
+
+    for event in ["BeforeTool", "AfterTool"] {
+        let entries = hooks
+            .entry(event.to_string())
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut()
+            .ok_or_else(|| {
+                Error::session(format!("gemini-antigravity hooks.{event} is not an array"))
+            })?;
+        entries.retain(|entry| {
+            !entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .is_some_and(|hooks| {
+                    hooks.iter().any(|hook| {
+                        hook.get("command")
+                            .and_then(|c| c.as_str())
+                            .is_some_and(|c| c.contains(&command_prefix))
+                    })
+                })
+        });
+        entries.push(serde_json::json!({
+            "matcher": MATCHER,
+            "hooks": [{
+                "type": "command",
+                "command": format!("{} hook {AGENT} {event}", binary.display()),
+            }]
+        }));
+    }
+
+    Ok(value)
+}
+
+fn remove_hooks(mut value: serde_json::Value) -> serde_json::Value {
+    let command_prefix = format!("concats hook {AGENT}");
+    if let Some(hooks) = value.get_mut("hooks").and_then(|h| h.as_object_mut()) {
+        for entries in hooks.values_mut() {
+            if let Some(arr) = entries.as_array_mut() {
+                arr.retain(|entry| {
+                    !entry
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .is_some_and(|hooks| {
+                            hooks.iter().any(|hook| {
+                                hook.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .is_some_and(|c| c.contains(&command_prefix))
+                            })
+                        })
+                });
+            }
+        }
+    }
+    value
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    mod install_hooks {
+        use super::*;
+
+        #[test]
+        fn preserves_other_hooks() {
+            let config = serde_json::json!({
+                "hooks": {
+                    "AfterTool": [
+                        { "matcher": "read_file", "hooks": [{ "type": "command", "command": "other-tool hook" }] },
+                        { "matcher": "write_file|replace", "hooks": [{ "type": "command", "command": "concats hook gemini-antigravity AfterTool" }] }
+                    ]
+                }
+            });
+
+            let config = install_hooks(config, Path::new("concats")).unwrap();
+
+            let data = serde_json::to_string(&config).unwrap();
+            assert!(data.contains("other-tool hook"));
+            assert!(data.contains("concats hook gemini-antigravity AfterTool"));
+            assert!(data.contains("concats hook gemini-antigravity BeforeTool"));
+            assert!(data.contains("\"enableHooks\":true"));
+        }
+    }
+
+    mod remove_hooks {
+        use super::*;
+
+        #[test]
+        fn removes_only_concats_hooks() {
+            let config = serde_json::json!({
+                "hooks": {
+                    "AfterTool": [
+                        { "matcher": "read_file", "hooks": [{ "type": "command", "command": "other-tool hook" }] },
+                        { "matcher": "write_file|replace", "hooks": [{ "type": "command", "command": "concats hook gemini-antigravity AfterTool" }] }
+                    ]
+                }
+            });
+
+            let config = remove_hooks(config);
+
+            let data = serde_json::to_string(&config).unwrap();
+            assert!(data.contains("other-tool hook"));
+            assert!(!data.contains("concats hook gemini-antigravity"));
+        }
+    }
+}

--- a/crates/hooks/src/git_hook.rs
+++ b/crates/hooks/src/git_hook.rs
@@ -1,0 +1,212 @@
+//! Install and manage git hooks that concats writes into `.git/hooks/`.
+//!
+//! Distinct from agent hooks (which live in agent-specific settings files),
+//! git hooks run on ordinary git operations. Today only `post-rewrite` is
+//! managed, so rebases and amends can rewrite session refs automatically.
+
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use concats_core::error::Result;
+
+const MARKER: &str = "# concats: managed";
+const HOOK_NAME: &str = "post-rewrite";
+
+/// Install status for a managed git hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookStatus {
+    /// No hook file exists.
+    Missing,
+    /// A concats-managed hook is installed.
+    Managed,
+    /// A hook exists but is not managed by concats.
+    Foreign,
+}
+
+/// Install the `post-rewrite` hook into the given git directory.
+///
+/// Writes a small shell script that invokes `<binary> rewrite "$@"`. Existing
+/// concats-managed hooks are overwritten in place; foreign hooks are left
+/// alone and the caller is expected to surface a warning.
+///
+/// # Errors
+///
+/// Returns an error if the hooks directory cannot be created, the hook file
+/// cannot be written, or its permissions cannot be set.
+pub fn install(gitdir: &Path, binary: &Path) -> Result<HookStatus> {
+    let hooks_dir = hooks_dir(gitdir);
+    fs::create_dir_all(&hooks_dir)?;
+    let path = hooks_dir.join(HOOK_NAME);
+
+    match status_at(&path) {
+        HookStatus::Foreign => return Ok(HookStatus::Foreign),
+        HookStatus::Missing | HookStatus::Managed => {}
+    }
+
+    let script = render_script(binary);
+    write_executable(&path, &script)?;
+    Ok(HookStatus::Managed)
+}
+
+/// Remove the concats-managed `post-rewrite` hook.
+///
+/// Foreign hooks are left untouched.
+///
+/// # Errors
+///
+/// Returns an error if the hook file cannot be removed.
+pub fn uninstall(gitdir: &Path) -> Result<HookStatus> {
+    let path = hooks_dir(gitdir).join(HOOK_NAME);
+    match status_at(&path) {
+        HookStatus::Managed => {
+            fs::remove_file(&path)?;
+            Ok(HookStatus::Missing)
+        }
+        status @ (HookStatus::Foreign | HookStatus::Missing) => Ok(status),
+    }
+}
+
+/// Report whether a concats-managed hook is present in the given git directory.
+#[must_use]
+pub fn status(gitdir: &Path) -> HookStatus {
+    status_at(&hooks_dir(gitdir).join(HOOK_NAME))
+}
+
+fn hooks_dir(gitdir: &Path) -> PathBuf {
+    gitdir.join("hooks")
+}
+
+fn status_at(path: &Path) -> HookStatus {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return HookStatus::Missing;
+    };
+    if contents.contains(MARKER) {
+        HookStatus::Managed
+    } else {
+        HookStatus::Foreign
+    }
+}
+
+fn render_script(binary: &Path) -> String {
+    format!(
+        "#!/bin/sh\n{MARKER}\nexec {} rewrite \"$@\"\n",
+        shell_quote(binary)
+    )
+}
+
+fn shell_quote(path: &Path) -> String {
+    let rendered = path.to_string_lossy();
+    if rendered
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '-' | '.'))
+    {
+        rendered.into_owned()
+    } else {
+        let escaped = rendered.replace('\'', "'\\''");
+        format!("'{escaped}'")
+    }
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, contents: &str) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(path)?;
+    file.write_all(contents.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_executable(path: &Path, contents: &str) -> Result<()> {
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    fn init_git_repo(dir: &Path) -> PathBuf {
+        git2::Repository::init(dir).unwrap();
+        dir.join(".git")
+    }
+
+    #[test]
+    fn install_creates_executable_hook_with_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let gitdir = init_git_repo(dir.path());
+        let binary = PathBuf::from("/usr/local/bin/concats");
+
+        let result = super::install(&gitdir, &binary).unwrap();
+        assert_eq!(result, HookStatus::Managed);
+
+        let hook = gitdir.join("hooks").join(HOOK_NAME);
+        let contents = fs::read_to_string(&hook).unwrap();
+        assert!(contents.contains(MARKER));
+        assert!(contents.contains("/usr/local/bin/concats"));
+        let mode = fs::metadata(&hook).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
+    }
+
+    #[test]
+    fn install_overwrites_managed_hook_and_preserves_foreign() {
+        let dir = tempfile::tempdir().unwrap();
+        let gitdir = init_git_repo(dir.path());
+        let binary = PathBuf::from("/concats");
+        let hook = gitdir.join("hooks").join(HOOK_NAME);
+        fs::create_dir_all(hook.parent().unwrap()).unwrap();
+
+        // Foreign hook is preserved.
+        fs::write(&hook, "#!/bin/sh\necho foreign\n").unwrap();
+        let result = super::install(&gitdir, &binary).unwrap();
+        assert_eq!(result, HookStatus::Foreign);
+        assert_eq!(
+            fs::read_to_string(&hook).unwrap(),
+            "#!/bin/sh\necho foreign\n"
+        );
+
+        // Managed hook is overwritten.
+        fs::write(&hook, format!("#!/bin/sh\n{MARKER}\nold\n")).unwrap();
+        let result = super::install(&gitdir, &binary).unwrap();
+        assert_eq!(result, HookStatus::Managed);
+        let contents = fs::read_to_string(&hook).unwrap();
+        assert!(contents.contains("exec /concats rewrite"));
+    }
+
+    #[test]
+    fn uninstall_removes_only_managed_hook() {
+        let dir = tempfile::tempdir().unwrap();
+        let gitdir = init_git_repo(dir.path());
+        let binary = PathBuf::from("/concats");
+
+        super::install(&gitdir, &binary).unwrap();
+        assert_eq!(status(&gitdir), HookStatus::Managed);
+
+        super::uninstall(&gitdir).unwrap();
+        assert_eq!(status(&gitdir), HookStatus::Missing);
+
+        // Foreign hook is not removed.
+        let hook = gitdir.join("hooks").join(HOOK_NAME);
+        fs::write(&hook, "#!/bin/sh\necho foreign\n").unwrap();
+        let result = super::uninstall(&gitdir).unwrap();
+        assert_eq!(result, HookStatus::Foreign);
+        assert!(hook.exists());
+    }
+
+    #[test]
+    fn quotes_paths_with_spaces() {
+        let quoted = shell_quote(Path::new("/tmp/with space/concats"));
+        assert_eq!(quoted, "'/tmp/with space/concats'");
+    }
+}

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -99,6 +99,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod droid;
 pub mod gemini;
+pub mod git_hook;
 pub mod handler;
 pub mod helpers;
 pub mod json_config;

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -99,6 +99,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod droid;
 pub mod gemini;
+pub mod gemini_antigravity;
 pub mod git_hook;
 pub mod handler;
 pub mod helpers;
@@ -147,12 +148,13 @@ impl fmt::Display for dyn Agent + '_ {
     }
 }
 
-static ALL_AGENTS: [&'static dyn Agent; 9] = [
+static ALL_AGENTS: [&'static dyn Agent; 10] = [
     &claude::ClaudeAgent,
     &codex::CodexAgent,
     &cursor::CursorAgent,
     &windsurf::WindsurfAgent,
     &gemini::GeminiAgent,
+    &gemini_antigravity::GeminiAntigravityAgent,
     &copilot::CopilotAgent,
     &droid::DroidAgent,
     &amp::AmpAgent,
@@ -237,7 +239,15 @@ mod tests {
             assert_eq!(
                 names,
                 vec![
-                    "claude", "codex", "cursor", "windsurf", "gemini", "copilot", "droid", "amp",
+                    "claude",
+                    "codex",
+                    "cursor",
+                    "windsurf",
+                    "gemini",
+                    "gemini-antigravity",
+                    "copilot",
+                    "droid",
+                    "amp",
                     "opencode"
                 ]
             );

--- a/rfcs/session_storage.md
+++ b/rfcs/session_storage.md
@@ -182,6 +182,30 @@ When rewriting the active turn:
 - preserve snapshot parent 0 when a previous snapshot exists
 - repoint the snapshot's turn parent to the rewritten turn
 
+## Rebase and Commit Rewriting
+
+When branch history is rewritten (`git rebase`, `git commit --amend`, or any
+other operation that updates `refs/heads/*` with new commit SHAs), Concats
+mirrors the rewrite onto session and snapshot chains through a
+`post-rewrite` git hook. The hook receives a map of old-to-new commit OIDs
+and the `concats rewrite` subcommand rebuilds affected refs.
+
+The rewrite is bottom-up: turns in each session are processed from base to
+tip, so when a turn is reconstructed its previous-turn parent already
+reflects any upstream rewrite performed in the same pass. Trees, authors,
+committers, and commit messages are preserved verbatim; only parents are
+remapped. Sessions whose turns reference none of the rewritten commits are
+left untouched. Running the hook twice with the same input is a no-op.
+
+Dropped anchors — commits absent from the rewrite map, typically the result
+of an interactive rebase that removed a commit outright — are left in place
+as orphans rather than substituted. The turn was authored against that
+exact commit, and silently substituting a nearest ancestor would corrupt
+the recorded diff base. The session ref keeps orphan objects reachable
+(matching the auditability drawback already documented). Callers may emit a
+warning so users know the anchor is no longer reachable from the working
+branch.
+
 ## Loading and Traversal
 
 Turn loading works as follows:


### PR DESCRIPTION
Adds a dedicated hooks handler for the Gemini Antigravity coding assistant, configuring hooks in ~/.gemini/antigravity/settings.json.
